### PR TITLE
fix(ci): correct heredoc syntax in build-push workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -101,14 +101,14 @@ jobs:
           SYFT_VERSION="$(syft version | head -n 1 | sed 's/^Version: //')"
           GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           cat > attestations/sbom-metadata-${{ matrix.target }}.json <<EOF
-          {
-            "target": "${{ matrix.target }}",
-            "format": "cyclonedx-json",
-            "syft_version": "${SYFT_VERSION}",
-            "sbom_sha256": "${SBOM_SHA}",
-            "generated_at": "${GENERATED_AT}"
-          }
-          EOF
+{
+  "target": "${{ matrix.target }}",
+  "format": "cyclonedx-json",
+  "syft_version": "${SYFT_VERSION}",
+  "sbom_sha256": "${SBOM_SHA}",
+  "generated_at": "${GENERATED_AT}"
+}
+EOF
           cosign attest --yes \
             --predicate attestations/sbom-metadata-${{ matrix.target }}.json \
             --type https://artagon.dev/attestations/sbom-metadata/v1 \


### PR DESCRIPTION
Complete workflow audit found heredoc syntax issue in build-push.yml. This PR fixes the EOF terminator position while preserving variable expansion.

**Changes:**
- Move EOF terminator to column 0  
- Use unquoted heredoc (<<EOF) for variable substitution

**Audit Results:**
- ✅ release.yml - Fixed in PR #17
- ✅ build-push.yml - Fixed in this PR  
- ✅ ci-build.yml - No heredocs
- ✅ nightly-scan.yml - No heredocs

Relates to #18