### PR TITLE
feat(deps): add Renovate for automated base image digest management

### DIFF
--- a/.github/workflows/digest-refresh.yml
+++ b/.github/workflows/digest-refresh.yml
@@ -1,0 +1,153 @@
+name: Digest Refresh
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly on Monday at 6am UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (check only, no PR)'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io/${{ github.repository }}
+
+jobs:
+  check-updates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      has_updates: ${{ steps.check.outputs.has_updates }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Chainguard
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: cgr.dev
+          username: ${{ github.actor }}
+          password: ${{ secrets.CHAINGUARD_TOKEN }}
+        continue-on-error: true
+
+      - name: Check for updates
+        id: check
+        run: |
+          if ./scripts/refresh-versions.sh --check; then
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Summary
+        run: |
+          echo "## Digest Refresh Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          ./scripts/lockfile-util.sh summary >> $GITHUB_STEP_SUMMARY || true
+
+  apply-updates:
+    needs: check-updates
+    if: needs.check-updates.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Chainguard
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: cgr.dev
+          username: ${{ github.actor }}
+          password: ${{ secrets.CHAINGUARD_TOKEN }}
+        continue-on-error: true
+
+      - name: Apply updates
+        run: ./scripts/refresh-versions.sh --apply
+
+      - name: Validate lock files
+        run: ./scripts/lockfile-util.sh validate
+
+      - name: Generate PR body
+        id: pr-body
+        run: |
+          BODY=$(./scripts/lockfile-util.sh pr-body)
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): refresh base image digests"
+          title: "chore(deps): refresh base image digests"
+          body: ${{ steps.pr-body.outputs.body }}
+          branch: chore/digest-refresh
+          delete-branch: true
+          labels: |
+            dependencies
+            automated
+          reviewers: |
+            ${{ github.repository_owner }}
+
+      - name: Summary
+        run: |
+          echo "## Digest Refresh Applied" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request created with updated base image digests." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          ./scripts/lockfile-util.sh summary >> $GITHUB_STEP_SUMMARY || true
+
+  dry-run-summary:
+    needs: check-updates
+    if: needs.check-updates.outputs.has_updates == 'true' && github.event.inputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dry Run Summary
+        run: |
+          echo "## Digest Refresh - Dry Run" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Updates are available but dry run was enabled." >> $GITHUB_STEP_SUMMARY
+          echo "Run without dry_run to create a pull request." >> $GITHUB_STEP_SUMMARY

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,12 +6,59 @@ variable "SOURCE_DATE_EPOCH" {
   default = ""
 }
 
+# Base image digests - populated from versions/*.lock files
+# Override via: docker buildx bake --set *.args.WOLFI_DIGEST=sha256:...
+# Or set environment variables before running bake
+variable "WOLFI_DIGEST" {
+  default = ""
+}
+
+variable "ALPINE_DIGEST" {
+  default = ""
+}
+
+variable "UBI9_DIGEST" {
+  default = ""
+}
+
+variable "UBI9_MINIMAL_DIGEST" {
+  default = ""
+}
+
+variable "DISTROLESS_DIGEST" {
+  default = ""
+}
+
 target "common" {
   context   = "."
   args = {
     SOURCE_DATE_EPOCH = SOURCE_DATE_EPOCH
   }
   platforms = ["linux/amd64", "linux/arm64"]
+}
+
+# Common args for Chainguard images (Wolfi + Alpine bases)
+target "common-chainguard" {
+  args = {
+    WOLFI_DIGEST  = WOLFI_DIGEST
+    ALPINE_DIGEST = ALPINE_DIGEST
+  }
+}
+
+# Common args for Distroless images
+target "common-distroless" {
+  args = {
+    WOLFI_DIGEST      = WOLFI_DIGEST
+    ALPINE_DIGEST     = ALPINE_DIGEST
+    DISTROLESS_DIGEST = DISTROLESS_DIGEST
+  }
+}
+
+# Common args for UBI9 images
+target "common-ubi9" {
+  args = {
+    BUILDER_DIGEST = UBI9_DIGEST
+  }
 }
 
 group "default" {
@@ -37,7 +84,7 @@ group "default" {
 # Chainguard
 
 target "chainguard-jdk25" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-chainguard"]
   dockerfile = "images/chainguard/Dockerfile.jdk25"
   target     = "runtime-glibc"
   args = {
@@ -57,7 +104,7 @@ target "chainguard-jdk25-musl" {
 }
 
 target "chainguard-jdk26ea" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-chainguard"]
   dockerfile = "images/chainguard/Dockerfile.jdk26ea"
   args = {
     FLAVOR = "jdk26ea"
@@ -75,7 +122,7 @@ target "chainguard-jdk26ea-musl" {
 }
 
 target "chainguard-jdk26valhalla" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-chainguard"]
   dockerfile = "images/chainguard/Dockerfile.jdk26valhalla"
   args = {
     FLAVOR = "jdk26valhalla"
@@ -95,7 +142,7 @@ target "chainguard-jdk26valhalla-musl" {
 # Distroless
 
 target "distroless-jre25" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre25"
   args = {
     FLAVOR = "jdk25"
@@ -105,7 +152,7 @@ target "distroless-jre25" {
 }
 
 target "distroless-jre25-musl" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre25"
   args = {
     FLAVOR = "jdk25"
@@ -115,7 +162,7 @@ target "distroless-jre25-musl" {
 }
 
 target "distroless-jre26ea" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre26ea"
   args = {
     FLAVOR = "jdk26ea"
@@ -125,7 +172,7 @@ target "distroless-jre26ea" {
 }
 
 target "distroless-jre26ea-musl" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre26ea"
   args = {
     FLAVOR = "jdk26ea"
@@ -135,7 +182,7 @@ target "distroless-jre26ea-musl" {
 }
 
 target "distroless-jre26valhalla" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre26valhalla"
   args = {
     FLAVOR = "jdk26valhalla"
@@ -145,7 +192,7 @@ target "distroless-jre26valhalla" {
 }
 
 target "distroless-jre26valhalla-musl" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-distroless"]
   dockerfile = "images/distroless/Dockerfile.jre26valhalla"
   args = {
     FLAVOR = "jdk26valhalla"
@@ -157,7 +204,7 @@ target "distroless-jre26valhalla-musl" {
 # UBI9
 
 target "ubi9-jdk25" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-ubi9"]
   dockerfile = "images/ubi9/Dockerfile.jdk25"
   args = {
     FLAVOR = "jdk25"
@@ -167,7 +214,7 @@ target "ubi9-jdk25" {
 }
 
 target "ubi9-jdk26ea" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-ubi9"]
   dockerfile = "images/ubi9/Dockerfile.jdk26ea"
   args = {
     FLAVOR = "jdk26ea"
@@ -177,7 +224,7 @@ target "ubi9-jdk26ea" {
 }
 
 target "ubi9-jdk26valhalla" {
-  inherits   = ["common"]
+  inherits   = ["common", "common-ubi9"]
   dockerfile = "images/ubi9/Dockerfile.jdk26valhalla"
   args = {
     FLAVOR = "jdk26valhalla"

--- a/images/chainguard/Dockerfile.jdk25
+++ b/images/chainguard/Dockerfile.jdk25
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-ARG ALPINE_DIGEST="sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958"
-
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder-glibc
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder-glibc
 
 ARG FLAVOR=jdk25
 ARG LIBC=glibc
@@ -28,7 +26,8 @@ RUN set -eux; \
     tar -xzf /tmp/jdk.tar.gz -C /opt/jdk --strip-components=1; \
     rm -f /tmp/jdk.tar.gz
 
-FROM alpine:3.20@${ALPINE_DIGEST} AS builder-musl
+# renovate: datasource=docker
+FROM alpine:3.20@sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958 AS builder-musl
 
 ARG FLAVOR=jdk25
 ARG LIBC=musl
@@ -54,7 +53,8 @@ RUN set -eux; \
     tar -xzf /tmp/jdk.tar.gz -C /opt/jdk --strip-components=1; \
     rm -f /tmp/jdk.tar.gz
 
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS runtime-glibc
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS runtime-glibc
 
 ARG FLAVOR=jdk25
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}
@@ -94,7 +94,8 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 ENTRYPOINT ["java"]
 CMD ["--version"]
 
-FROM alpine:3.20@${ALPINE_DIGEST} AS runtime-musl
+# renovate: datasource=docker
+FROM alpine:3.20@sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958 AS runtime-musl
 
 ARG FLAVOR=jdk25
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/images/chainguard/Dockerfile.jdk26ea
+++ b/images/chainguard/Dockerfile.jdk26ea
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder
 
 ARG FLAVOR=jdk26ea
 ARG LIBC=glibc
@@ -29,7 +28,8 @@ RUN set -eux; \
 
 # Note: JDK 26 EA doesn't provide musl binaries, only glibc
 # Use Wolfi (glibc) runtime for both variants
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS runtime
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS runtime
 
 ARG FLAVOR=jdk26ea
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/images/chainguard/Dockerfile.jdk26valhalla
+++ b/images/chainguard/Dockerfile.jdk26valhalla
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder
 
 ARG FLAVOR=jdk26valhalla
 ARG LIBC=glibc
@@ -29,7 +28,8 @@ RUN set -eux; \
 
 # Note: JDK 26 Valhalla doesn't provide musl binaries, only glibc
 # Use Wolfi (glibc) runtime for both variants
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS runtime
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS runtime
 
 ARG FLAVOR=jdk26valhalla
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/images/distroless/Dockerfile.jre25
+++ b/images/distroless/Dockerfile.jre25
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.7
 ARG LIBC=glibc
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-ARG ALPINE_DIGEST="sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958"
 
-FROM alpine:3.20@${ALPINE_DIGEST} AS musl-loader
+# renovate: datasource=docker
+FROM alpine:3.20@sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958 AS musl-loader
 
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder
 
 ARG FLAVOR=jdk25
 ARG LIBC=glibc
@@ -70,7 +70,8 @@ RUN set -eux; \
 
 # Note: Distroless static-debian12 has no libc, cannot run JDK binaries
 # Use base-debian12 (glibc) for both variants
-FROM gcr.io/distroless/base-debian12@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
+# renovate: datasource=docker
+FROM gcr.io/distroless/base-debian12:latest@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
 
 ARG FLAVOR=jdk25
 ENV JAVA_HOME=/usr/lib/jvm/jre-${FLAVOR}

--- a/images/distroless/Dockerfile.jre26ea
+++ b/images/distroless/Dockerfile.jre26ea
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.7
 ARG LIBC=glibc
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-ARG ALPINE_DIGEST="sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958"
 
-FROM alpine:3.20@${ALPINE_DIGEST} AS musl-loader
+# renovate: datasource=docker
+FROM alpine:3.20@sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958 AS musl-loader
 
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder
 
 ARG FLAVOR=jdk26ea
 ARG LIBC=glibc
@@ -71,7 +71,8 @@ RUN set -eux; \
 
 # Note: Distroless static-debian12 has no libc, cannot run JDK binaries
 # Use base-debian12 (glibc) for both variants
-FROM gcr.io/distroless/base-debian12@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
+# renovate: datasource=docker
+FROM gcr.io/distroless/base-debian12:latest@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
 
 ARG FLAVOR=jdk26ea
 ENV JAVA_HOME=/usr/lib/jvm/jre-${FLAVOR}

--- a/images/distroless/Dockerfile.jre26valhalla
+++ b/images/distroless/Dockerfile.jre26valhalla
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.7
 ARG LIBC=glibc
-ARG WOLFI_DIGEST="sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344"
-ARG ALPINE_DIGEST="sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958"
 
-FROM alpine:3.20@${ALPINE_DIGEST} AS musl-loader
+# renovate: datasource=docker
+FROM alpine:3.20@sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958 AS musl-loader
 
-FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST} AS builder
+# renovate: datasource=docker
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344 AS builder
 
 ARG FLAVOR=jdk26valhalla
 ARG LIBC=glibc
@@ -71,7 +71,8 @@ RUN set -eux; \
 
 # Note: Distroless static-debian12 has no libc, cannot run JDK binaries
 # Use base-debian12 (glibc) for both variants
-FROM gcr.io/distroless/base-debian12@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
+# renovate: datasource=docker
+FROM gcr.io/distroless/base-debian12:latest@sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce AS runtime
 
 ARG FLAVOR=jdk26valhalla
 ENV JAVA_HOME=/usr/lib/jvm/jre-${FLAVOR}

--- a/images/ubi9/Dockerfile.jdk25
+++ b/images/ubi9/Dockerfile.jdk25
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG BUILDER_DIGEST="sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04"
-FROM registry.access.redhat.com/ubi9/ubi@${BUILDER_DIGEST} AS builder
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04 AS builder
 
 ARG FLAVOR=jdk25
 ARG LIBC=glibc
@@ -28,7 +28,8 @@ RUN set -eux; \
     tar -xzf /tmp/jdk.tar.gz -C /opt/jdk --strip-components=1; \
     rm -f /tmp/jdk.tar.gz
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
 
 ARG FLAVOR=jdk25
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/images/ubi9/Dockerfile.jdk26ea
+++ b/images/ubi9/Dockerfile.jdk26ea
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG BUILDER_DIGEST="sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04"
-FROM registry.access.redhat.com/ubi9/ubi@${BUILDER_DIGEST} AS builder
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04 AS builder
 
 ARG FLAVOR=jdk26ea
 ARG LIBC=glibc
@@ -28,7 +28,8 @@ RUN set -eux; \
     tar -xzf /tmp/jdk.tar.gz -C /opt/jdk --strip-components=1; \
     rm -f /tmp/jdk.tar.gz
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
 
 ARG FLAVOR=jdk26ea
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/images/ubi9/Dockerfile.jdk26valhalla
+++ b/images/ubi9/Dockerfile.jdk26valhalla
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
-ARG BUILDER_DIGEST="sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04"
-FROM registry.access.redhat.com/ubi9/ubi@${BUILDER_DIGEST} AS builder
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04 AS builder
 
 ARG FLAVOR=jdk26valhalla
 ARG LIBC=glibc
@@ -28,7 +28,8 @@ RUN set -eux; \
     tar -xzf /tmp/jdk.tar.gz -C /opt/jdk --strip-components=1; \
     rm -f /tmp/jdk.tar.gz
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+# renovate: datasource=docker
+FROM registry.access.redhat.com/ubi9-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
 
 ARG FLAVOR=jdk26valhalla
 ENV JAVA_HOME=/usr/lib/jvm/jdk-${FLAVOR}

--- a/openspec/changes/add-digest-refresh-workflow/proposal.md
+++ b/openspec/changes/add-digest-refresh-workflow/proposal.md
@@ -1,0 +1,53 @@
+# Automated Digest Refresh Workflow with Package Lock Files
+
+## Why
+
+Base image updates currently require manual coordination between digest pins and package version pins. When base images are updated, package versions change, causing build failures if Dockerfiles have hardcoded version pins. The recent PR #43 demonstrated this issue: updating Wolfi/Alpine/Distroless/UBI9 digests broke builds because glibc, bind-tools, and other packages had newer versions.
+
+A lock file approach (similar to npm/cargo) provides:
+- **Reproducibility**: Exact package versions are recorded and auditable
+- **Atomicity**: Digests and package versions update together
+- **Automation**: Weekly scheduled refresh with automatic PR creation
+- **Auditability**: Git history shows exactly what changed and when
+
+## What Changes
+
+This proposal introduces an automated digest-refresh workflow with package version lock files:
+
+- **Lock file structure**: Create `versions/*.lock` files for each base image family (Wolfi, Alpine, UBI9, Distroless) containing digest and package versions
+- **Version detection script**: Create `scripts/refresh-versions.sh` that queries container images for available package versions
+- **Bake integration**: Modify `docker-bake.hcl` to read versions from lock files via variable injection
+- **GitHub Actions workflow**: Create `.github/workflows/digest-refresh.yml` with weekly schedule and manual dispatch
+- **Dockerfile updates**: Convert hardcoded versions to ARG references populated from lock files
+
+**No breaking changes** - builds continue to work; lock files are additive.
+
+## Impact
+
+**Affected specs**:
+- `digest-refresh` (NEW) - Automated base image and package version management
+
+**Affected code**:
+- Lock files: `versions/{wolfi,alpine,ubi9,distroless}.lock`
+- Scripts: `scripts/refresh-versions.sh`
+- Build: `docker-bake.hcl` (add variable definitions)
+- Workflows: `.github/workflows/digest-refresh.yml`
+- Dockerfiles: All 9 Dockerfiles (convert to ARG-based versions)
+
+**Dependencies**:
+- Docker CLI for image inspection (`docker manifest inspect`, `docker run`)
+- GitHub Actions for scheduled runs and PR creation
+- `jq` for JSON parsing in scripts
+
+**Benefits**:
+- Eliminates manual digest/version synchronization
+- Provides full audit trail of base image changes
+- Enables reproducible builds at any point in history
+- Reduces security response time (automated CVE remediation via base image updates)
+- PRs clearly show what packages changed and their versions
+
+**Risks**:
+- Lock file format must be stable (breaking changes require migration)
+- Package queries require pulling images (CI resource usage)
+- Some packages may not have stable version output formats
+- Network failures during version detection need retry logic

--- a/openspec/changes/add-digest-refresh-workflow/specs/digest-refresh/spec.md
+++ b/openspec/changes/add-digest-refresh-workflow/specs/digest-refresh/spec.md
@@ -1,0 +1,156 @@
+# Digest Refresh Workflow Specification
+
+## ADDED Requirements
+
+### Requirement: Lock File Structure
+
+The project SHALL maintain package version lock files in `versions/` directory that record:
+- Base image digest (immutable reference)
+- Package versions available in that base image
+- Timestamp of last update
+- Source registry information
+
+Lock files SHALL use JSON format with the following structure:
+
+```json
+{
+  "registry": "cgr.dev/chainguard/wolfi-base",
+  "digest": "sha256:...",
+  "updated": "2026-01-27T10:00:00Z",
+  "packages": {
+    "curl": "8.17.0-r0",
+    "bash": "5.3-r3",
+    "glibc": "2.42-r4"
+  }
+}
+```
+
+#### Scenario: Lock file exists for base image
+
+- **GIVEN** a Dockerfile uses `cgr.dev/chainguard/wolfi-base`
+- **WHEN** the build system reads the lock file
+- **THEN** it SHALL use the digest from `versions/wolfi.lock`
+- **AND** package versions SHALL be available for injection into Dockerfiles
+
+#### Scenario: Lock file is missing
+
+- **GIVEN** a lock file does not exist for a base image
+- **WHEN** the build is attempted
+- **THEN** the build SHALL fail with a clear error message
+- **AND** instructions SHALL be provided to generate the lock file
+
+### Requirement: Version Detection Script
+
+The project SHALL provide `scripts/refresh-versions.sh` that:
+- Detects available package versions from container images
+- Supports multiple package managers (apk, rpm, dpkg)
+- Compares current lock file with available versions
+- Updates lock files atomically when changes are detected
+
+The script SHALL support the following modes:
+- `--check`: Report if updates are available (exit 0 if current, exit 1 if updates available)
+- `--apply`: Update lock files with detected versions
+- `--diff`: Show differences between current and available versions
+
+#### Scenario: New base image digest available
+
+- **WHEN** `refresh-versions.sh --check` is run
+- **AND** a base image has a newer digest than recorded in the lock file
+- **THEN** the script SHALL exit with code 1
+- **AND** output SHALL indicate which images have updates
+
+#### Scenario: Applying version updates
+
+- **WHEN** `refresh-versions.sh --apply` is run
+- **AND** updates are available
+- **THEN** the script SHALL update all affected lock files
+- **AND** each lock file SHALL have updated `digest`, `packages`, and `updated` fields
+- **AND** the script SHALL output a summary of changes
+
+#### Scenario: No updates available
+
+- **WHEN** `refresh-versions.sh --check` is run
+- **AND** all lock files are current
+- **THEN** the script SHALL exit with code 0
+- **AND** output SHALL indicate no updates found
+
+### Requirement: Bake Integration
+
+The `docker-bake.hcl` file SHALL define variables that are populated from lock files:
+- `WOLFI_DIGEST` - Wolfi base image digest
+- `ALPINE_DIGEST` - Alpine base image digest
+- `UBI9_DIGEST` - UBI9 base image digest
+- `UBI9_MINIMAL_DIGEST` - UBI9-minimal base image digest
+- `DISTROLESS_DIGEST` - Distroless base image digest
+
+Variables SHALL be injected via a helper script or CI environment.
+
+#### Scenario: Building with bake variables
+
+- **WHEN** `docker buildx bake` is invoked
+- **THEN** digest variables SHALL be populated from lock files
+- **AND** Dockerfiles SHALL receive correct digest values via ARG
+
+### Requirement: Automated Refresh Workflow
+
+The project SHALL provide `.github/workflows/digest-refresh.yml` that:
+- Runs on a weekly schedule (configurable, default Sunday 02:00 UTC)
+- Supports manual dispatch via `workflow_dispatch`
+- Detects base image updates using the version detection script
+- Creates a pull request when updates are found
+
+The workflow SHALL NOT push directly to main; all changes require PR review.
+
+#### Scenario: Weekly refresh finds updates
+
+- **WHEN** the scheduled workflow runs
+- **AND** base image updates are detected
+- **THEN** the workflow SHALL create a branch `chore/refresh-base-images-YYYY-MM-DD`
+- **AND** commit updated lock files to the branch
+- **AND** create a pull request with title "chore(deps): refresh base image digests"
+- **AND** the PR description SHALL list all changed images and versions
+
+#### Scenario: Weekly refresh finds no updates
+
+- **WHEN** the scheduled workflow runs
+- **AND** no base image updates are detected
+- **THEN** the workflow SHALL complete successfully
+- **AND** no branch or PR SHALL be created
+- **AND** the workflow summary SHALL indicate no updates found
+
+#### Scenario: Manual refresh trigger
+
+- **WHEN** a user triggers `workflow_dispatch`
+- **THEN** the workflow SHALL run the same refresh logic
+- **AND** create a PR if updates are found
+
+### Requirement: PR Content
+
+Pull requests created by the digest-refresh workflow SHALL include:
+- Clear title indicating automated dependency update
+- Table showing old vs new digests for each base image
+- Table showing changed package versions (if applicable)
+- Labels: `dependencies`, `automated`
+- Link to workflow run for audit trail
+
+#### Scenario: PR description format
+
+- **WHEN** a refresh PR is created
+- **THEN** the PR body SHALL contain:
+  ```markdown
+  ## Base Image Updates
+
+  | Image | Old Digest | New Digest |
+  |-------|-----------|------------|
+  | wolfi-base | sha256:abc... | sha256:def... |
+
+  ## Package Changes
+
+  ### Wolfi
+  | Package | Old Version | New Version |
+  |---------|-------------|-------------|
+  | glibc | 2.42-r3 | 2.42-r4 |
+
+  ---
+  Workflow run: [link]
+  ```

--- a/openspec/changes/add-digest-refresh-workflow/tasks.md
+++ b/openspec/changes/add-digest-refresh-workflow/tasks.md
@@ -1,0 +1,62 @@
+# Implementation Tasks
+
+## 1. Lock File Structure
+
+- [x] 1.1 Create `versions/` directory
+- [x] 1.2 Define lock file format (JSON with digest + packages)
+- [x] 1.3 Create initial `versions/wolfi.lock` with current Wolfi digest and package versions
+- [x] 1.4 Create initial `versions/alpine.lock` with current Alpine digest and package versions
+- [x] 1.5 Create initial `versions/ubi9.lock` with current UBI9 digests and package info
+- [x] 1.6 Create initial `versions/distroless.lock` with current Distroless digest
+
+## 2. Version Detection Script
+
+- [x] 2.1 Create `scripts/refresh-versions.sh` with subcommands: `detect`, `update`, `diff`
+- [x] 2.2 Implement Wolfi version detection via `docker run ... apk info`
+- [x] 2.3 Implement Alpine version detection via `docker run ... apk info`
+- [x] 2.4 Implement UBI9 version detection via `docker run ... rpm -qa`
+- [x] 2.5 Implement Distroless digest detection via `docker manifest inspect`
+- [x] 2.6 Add `--check` mode to detect if updates are available without modifying files
+- [x] 2.7 Add `--apply` mode to update lock files in place
+- [ ] 2.8 Add retry logic for transient network failures
+
+## 3. Bake Integration
+
+- [x] 3.1 Add variable block to `docker-bake.hcl` for lock file values
+- [x] 3.2 Create helper script or use `jq` to extract values from lock files (`scripts/lockfile-util.sh`)
+- [x] 3.3 Update bake targets to use variables for digests
+- [ ] 3.4 Verify bake builds work with variable injection
+
+## 4. Dockerfile Updates
+
+- [ ] 4.1 Update Chainguard Dockerfiles to use ARG for WOLFI_DIGEST from bake
+- [ ] 4.2 Update Chainguard Dockerfiles to use ARG for ALPINE_DIGEST from bake
+- [ ] 4.3 Update Distroless Dockerfiles to use ARG for digests from bake
+- [ ] 4.4 Update UBI9 Dockerfiles to use ARG for digests from bake
+- [ ] 4.5 Verify all Dockerfiles build correctly with injected values
+
+## 5. GitHub Actions Workflow
+
+- [x] 5.1 Create `.github/workflows/digest-refresh.yml`
+- [x] 5.2 Configure weekly schedule trigger (Monday 06:00 UTC)
+- [x] 5.3 Configure manual workflow_dispatch trigger with dry_run option
+- [x] 5.4 Implement step to run `refresh-versions.sh --check`
+- [x] 5.5 Implement step to run `refresh-versions.sh --apply` if updates found
+- [x] 5.6 Implement step to create PR with updated lock files
+- [x] 5.7 Include detailed PR description showing old vs new versions
+- [x] 5.8 Add labels to PR (`dependencies`, `automated`)
+
+## 6. Documentation
+
+- [ ] 6.1 Document lock file format in `docs/lock-files.md`
+- [ ] 6.2 Document manual refresh process
+- [ ] 6.3 Update CLAUDE.md with lock file conventions
+- [ ] 6.4 Add troubleshooting section for common issues
+
+## 7. Validation
+
+- [ ] 7.1 Run `openspec validate add-digest-refresh-workflow --strict`
+- [ ] 7.2 Test workflow via manual dispatch
+- [ ] 7.3 Verify PR creation works correctly
+- [ ] 7.4 Verify CI builds pass with lock file values
+- [ ] 7.5 Test rollback scenario (revert to previous lock file)

--- a/openspec/changes/add-renovate-integration/proposal.md
+++ b/openspec/changes/add-renovate-integration/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: Replace Custom Digest Refresh with Renovate
+
+## Why
+
+PR #45 introduced a custom solution for base image digest management with lock files and shell scripts. While functional, this approach:
+
+- Requires ongoing maintenance of custom scripts
+- Lacks retry logic, rate limiting, and error handling at scale
+- Only supports Docker (not Helm, npm, or other ecosystems)
+- Doesn't handle PR conflict resolution automatically
+
+Renovate is an industry-standard dependency management tool that handles all of this out of the box.
+
+## What
+
+Replace the custom digest-refresh workflow with Renovate:
+
+1. **Add Renovate configuration** (`renovate.json`)
+   - Enable `docker:pinDigests` preset
+   - Configure weekly schedule (Monday 06:00 UTC)
+   - Group base image updates together
+
+2. **Update Dockerfiles** to use Renovate's digest pinning format:
+   ```dockerfile
+   # Before (tag only)
+   FROM cgr.dev/chainguard/wolfi-base:latest
+
+   # After (tag + digest, Renovate-managed)
+   FROM cgr.dev/chainguard/wolfi-base:latest@sha256:abc123...
+   ```
+
+3. **Enable Renovate** via GitHub App or self-hosted action
+
+4. **Deprecate custom scripts** (keep for reference or remove entirely)
+
+## Impact
+
+### Removed/Deprecated
+- `.github/workflows/digest-refresh.yml` - replaced by Renovate
+- `scripts/refresh-versions.sh` - no longer needed
+- `scripts/lockfile-util.sh` - no longer needed
+- `versions/*.lock` - Renovate manages digests inline in Dockerfiles
+
+### Added
+- `renovate.json` - Renovate configuration
+- Inline digest pins in all Dockerfiles
+
+### Modified
+- All Dockerfiles updated to include `@sha256:...` digest pins
+- `docker-bake.hcl` - remove digest variables (optional, can keep for manual override)
+
+## Benefits
+
+| Aspect | Custom Solution | Renovate |
+|--------|-----------------|----------|
+| Maintenance | Team-maintained | Community-maintained |
+| Error handling | Basic | Robust (retries, rate limits) |
+| Ecosystems | Docker only | Docker, npm, Helm, K8s, Terraform, etc. |
+| PR management | Manual | Auto-rebase, conflict resolution |
+| Scheduling | Basic cron | Rich schedule expressions |
+| Grouping | None | Group related updates |
+| Dashboard | None | Dependency dashboard issue |
+
+## Links
+
+- Issue: #46
+- Supersedes: #44, PR #45
+- [Renovate Docker Docs](https://docs.renovatebot.com/docker/)

--- a/openspec/changes/add-renovate-integration/specs/renovate-integration/spec.md
+++ b/openspec/changes/add-renovate-integration/specs/renovate-integration/spec.md
@@ -1,0 +1,157 @@
+# Spec: Renovate Integration for Base Image Management
+
+## Overview
+
+Renovate automates dependency updates including Docker base image digests. This spec defines the configuration and behavior for Renovate in this repository.
+
+## Requirements
+
+### REQ-1: Digest Pinning Format
+
+All Dockerfiles MUST use the tag+digest format for base images:
+
+```dockerfile
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:abc123...
+```
+
+**Rationale**: This format maintains readability (tag visible) while ensuring reproducibility (digest pinned).
+
+#### Scenarios
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| 1.1 | Dockerfile has tag only | Renovate adds digest |
+| 1.2 | Dockerfile has tag+digest | Renovate updates digest when upstream changes |
+| 1.3 | Multi-stage build | All FROM lines are pinned |
+
+### REQ-2: Update Schedule
+
+Renovate MUST check for updates weekly on Monday at 06:00 UTC.
+
+**Rationale**: Weekly updates balance security (timely patches) with stability (not too frequent).
+
+#### Scenarios
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| 2.1 | No updates available | No PR created |
+| 2.2 | Updates available | PR created with all updates |
+| 2.3 | Manual trigger | Updates checked immediately |
+
+### REQ-3: PR Grouping
+
+Base image updates SHOULD be grouped into a single PR per image family.
+
+**Rationale**: Reduces PR noise while maintaining logical separation.
+
+#### Groups
+
+| Group | Images |
+|-------|--------|
+| chainguard | wolfi-base, alpine |
+| distroless | base-debian12 |
+| ubi9 | ubi9/ubi, ubi9-minimal |
+
+#### Scenarios
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| 3.1 | Wolfi and Alpine both updated | Single PR for Chainguard group |
+| 3.2 | UBI9 updated | Separate PR for UBI9 group |
+| 3.3 | All images updated | 3 PRs (one per group) |
+
+### REQ-4: CI Integration
+
+Renovate PRs MUST trigger the existing CI workflow for validation.
+
+#### Scenarios
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| 4.1 | Renovate PR created | CI builds all affected images |
+| 4.2 | CI passes | PR ready for review |
+| 4.3 | CI fails | PR blocked, requires investigation |
+
+### REQ-5: Dependency Dashboard
+
+Renovate MUST maintain a dependency dashboard issue for visibility.
+
+**Rationale**: Provides single view of all pending updates and Renovate status.
+
+#### Scenarios
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| 5.1 | First run | Dashboard issue created |
+| 5.2 | Updates pending | Dashboard shows pending PRs |
+| 5.3 | All up to date | Dashboard shows green status |
+
+## Configuration
+
+### renovate.json
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "schedule:weekly"
+  ],
+  "timezone": "UTC",
+  "schedule": ["before 6am on monday"],
+  "packageRules": [
+    {
+      "description": "Group Chainguard base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^cgr\\.dev/chainguard/", "^alpine$"],
+      "groupName": "chainguard-base-images"
+    },
+    {
+      "description": "Group Distroless base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^gcr\\.io/distroless/"],
+      "groupName": "distroless-base-images"
+    },
+    {
+      "description": "Group UBI9 base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^registry\\.access\\.redhat\\.com/ubi9"],
+      "groupName": "ubi9-base-images"
+    }
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard"
+}
+```
+
+## Migration from Custom Solution
+
+### Files to Remove
+
+After Renovate is stable:
+
+- `.github/workflows/digest-refresh.yml`
+- `scripts/refresh-versions.sh`
+- `scripts/lockfile-util.sh`
+- `versions/*.lock`
+
+### docker-bake.hcl Changes
+
+The digest variables can be removed or kept for manual override:
+
+```hcl
+# Optional: Keep for manual override capability
+variable "WOLFI_DIGEST" {
+  default = ""  # Empty = use Dockerfile value
+}
+```
+
+## Acceptance Criteria
+
+- [ ] Renovate configuration file exists and is valid
+- [ ] All Dockerfiles use tag+digest format
+- [ ] Renovate creates PRs for outdated digests
+- [ ] PRs trigger CI and pass validation
+- [ ] Dependency dashboard issue is maintained
+- [ ] Custom solution is removed or deprecated

--- a/openspec/changes/add-renovate-integration/tasks.md
+++ b/openspec/changes/add-renovate-integration/tasks.md
@@ -1,0 +1,49 @@
+# Implementation Tasks
+
+## 1. Renovate Configuration
+
+- [x] 1.1 Create `renovate.json` with base configuration
+- [x] 1.2 Enable `docker:pinDigests` preset
+- [x] 1.3 Configure schedule (weekly Monday 06:00 UTC)
+- [x] 1.4 Add package rules for base image grouping
+- [ ] 1.5 Configure automerge settings (optional)
+
+## 2. Dockerfile Updates
+
+- [x] 2.1 Update `images/chainguard/Dockerfile.jdk25` with digest pin
+- [x] 2.2 Update `images/chainguard/Dockerfile.jdk26ea` with digest pin
+- [x] 2.3 Update `images/chainguard/Dockerfile.jdk26valhalla` with digest pin
+- [x] 2.4 Update `images/distroless/Dockerfile.jre25` with digest pin
+- [x] 2.5 Update `images/distroless/Dockerfile.jre26ea` with digest pin
+- [x] 2.6 Update `images/distroless/Dockerfile.jre26valhalla` with digest pin
+- [x] 2.7 Update `images/ubi9/Dockerfile.jdk25` with digest pin
+- [x] 2.8 Update `images/ubi9/Dockerfile.jdk26ea` with digest pin
+- [x] 2.9 Update `images/ubi9/Dockerfile.jdk26valhalla` with digest pin
+
+## 3. Enable Renovate
+
+- [ ] 3.1 Install Renovate GitHub App on repository
+- [ ] 3.2 Verify Renovate creates onboarding PR
+- [ ] 3.3 Review and merge onboarding PR
+- [ ] 3.4 Verify dependency dashboard issue is created
+
+## 4. Cleanup Custom Solution
+
+- [ ] 4.1 Remove `.github/workflows/digest-refresh.yml`
+- [ ] 4.2 Remove `scripts/refresh-versions.sh`
+- [ ] 4.3 Remove `scripts/lockfile-util.sh`
+- [ ] 4.4 Remove `versions/` directory and lock files
+- [ ] 4.5 Simplify `docker-bake.hcl` (remove digest variables if not needed)
+
+## 5. Documentation
+
+- [ ] 5.1 Update CLAUDE.md with Renovate conventions
+- [ ] 5.2 Document how to handle Renovate PRs
+- [ ] 5.3 Document manual digest update process (if needed)
+
+## 6. Validation
+
+- [ ] 6.1 Verify Renovate detects all Dockerfiles
+- [ ] 6.2 Verify Renovate creates PRs for outdated digests
+- [ ] 6.3 Verify CI builds pass with Renovate-managed digests
+- [ ] 6.4 Test manual workflow dispatch still works (if kept)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "schedule:weekly"
+  ],
+  "timezone": "UTC",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies", "automated"],
+  "packageRules": [
+    {
+      "description": "Group Chainguard base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^cgr\\.dev/chainguard/", "^alpine$"],
+      "groupName": "chainguard-base-images"
+    },
+    {
+      "description": "Group Distroless base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^gcr\\.io/distroless/"],
+      "groupName": "distroless-base-images"
+    },
+    {
+      "description": "Group UBI9 base images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^registry\\.access\\.redhat\\.com/ubi9"],
+      "groupName": "ubi9-base-images"
+    }
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10
+}

--- a/scripts/lockfile-util.sh
+++ b/scripts/lockfile-util.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# lockfile-util.sh - Utilities for working with version lock files
+#
+# Usage:
+#   ./scripts/lockfile-util.sh get <lock> <key>        # Get a value from lock file
+#   ./scripts/lockfile-util.sh digest <image>          # Get digest for image type
+#   ./scripts/lockfile-util.sh env                     # Output as environment variables
+#   ./scripts/lockfile-util.sh bake-vars              # Output as docker-bake HCL variables
+#   ./scripts/lockfile-util.sh validate               # Validate all lock files
+#   ./scripts/lockfile-util.sh summary                # Show summary of all lock files
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERSIONS_DIR="${REPO_ROOT}/versions"
+
+# Get a value from a lock file
+get_value() {
+  local lock_file="$1"
+  local key="$2"
+
+  if [[ ! -f "${VERSIONS_DIR}/${lock_file}.lock" ]]; then
+    echo "Error: Lock file not found: ${lock_file}.lock" >&2
+    return 1
+  fi
+
+  jq -r "${key}" "${VERSIONS_DIR}/${lock_file}.lock"
+}
+
+# Get digest for a specific image type
+get_digest() {
+  local image_type="$1"
+
+  case "${image_type}" in
+    wolfi)
+      get_value wolfi '.digest'
+      ;;
+    alpine)
+      get_value alpine '.digest'
+      ;;
+    ubi9)
+      get_value ubi9 '.digest'
+      ;;
+    ubi9-minimal)
+      get_value ubi9 '.minimal.digest'
+      ;;
+    distroless)
+      get_value distroless '.digest'
+      ;;
+    *)
+      echo "Error: Unknown image type: ${image_type}" >&2
+      echo "Valid types: wolfi, alpine, ubi9, ubi9-minimal, distroless" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Output as environment variables (for CI)
+output_env() {
+  echo "# Generated from version lock files"
+  echo "# Source this file or use: eval \$(./scripts/lockfile-util.sh env)"
+  echo ""
+  echo "export WOLFI_DIGEST=\"$(get_value wolfi '.digest')\""
+  echo "export ALPINE_DIGEST=\"$(get_value alpine '.digest')\""
+  echo "export UBI9_DIGEST=\"$(get_value ubi9 '.digest')\""
+  echo "export UBI9_MINIMAL_DIGEST=\"$(get_value ubi9 '.minimal.digest')\""
+  echo "export DISTROLESS_DIGEST=\"$(get_value distroless '.digest')\""
+}
+
+# Output as docker-bake HCL variables
+output_bake_vars() {
+  cat <<EOF
+// Auto-generated from version lock files
+// Do not edit manually - run: ./scripts/refresh-versions.sh --apply
+
+variable "WOLFI_DIGEST" {
+  default = "$(get_value wolfi '.digest')"
+}
+
+variable "ALPINE_DIGEST" {
+  default = "$(get_value alpine '.digest')"
+}
+
+variable "UBI9_DIGEST" {
+  default = "$(get_value ubi9 '.digest')"
+}
+
+variable "UBI9_MINIMAL_DIGEST" {
+  default = "$(get_value ubi9 '.minimal.digest')"
+}
+
+variable "DISTROLESS_DIGEST" {
+  default = "$(get_value distroless '.digest')"
+}
+EOF
+}
+
+# Validate all lock files
+validate_locks() {
+  local errors=0
+
+  echo "Validating lock files..."
+  echo ""
+
+  for lock_file in "${VERSIONS_DIR}"/*.lock; do
+    local name
+    name=$(basename "${lock_file}" .lock)
+
+    # Check JSON validity
+    if ! jq empty "${lock_file}" 2>/dev/null; then
+      echo "❌ ${name}.lock: Invalid JSON"
+      ((errors++))
+      continue
+    fi
+
+    # Check required fields
+    local digest
+    digest=$(jq -r '.digest // empty' "${lock_file}")
+    if [[ -z "${digest}" ]]; then
+      echo "❌ ${name}.lock: Missing 'digest' field"
+      ((errors++))
+      continue
+    fi
+
+    # Check digest format
+    if [[ ! "${digest}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+      echo "❌ ${name}.lock: Invalid digest format: ${digest}"
+      ((errors++))
+      continue
+    fi
+
+    local registry
+    registry=$(jq -r '.registry // empty' "${lock_file}")
+    if [[ -z "${registry}" ]]; then
+      echo "❌ ${name}.lock: Missing 'registry' field"
+      ((errors++))
+      continue
+    fi
+
+    local updated
+    updated=$(jq -r '.updated // empty' "${lock_file}")
+    if [[ -z "${updated}" ]]; then
+      echo "⚠️  ${name}.lock: Missing 'updated' timestamp"
+    fi
+
+    echo "✅ ${name}.lock: Valid"
+  done
+
+  echo ""
+  if [[ ${errors} -gt 0 ]]; then
+    echo "Validation failed with ${errors} error(s)"
+    return 1
+  fi
+
+  echo "All lock files are valid"
+  return 0
+}
+
+# Show summary of all lock files
+show_summary() {
+  echo "╔════════════════════════════════════════════════════════════════════════════╗"
+  echo "║                           Version Lock Files Summary                        ║"
+  echo "╠════════════════════════════════════════════════════════════════════════════╣"
+
+  for lock_file in "${VERSIONS_DIR}"/*.lock; do
+    local name registry digest updated
+    name=$(basename "${lock_file}" .lock)
+    registry=$(jq -r '.registry' "${lock_file}")
+    digest=$(jq -r '.digest' "${lock_file}")
+    updated=$(jq -r '.updated // "unknown"' "${lock_file}")
+
+    printf "║ %-12s %-50s ║\n" "${name}:" "${registry}"
+    printf "║   Digest:   %-60s ║\n" "${digest:0:50}..."
+    printf "║   Updated:  %-60s ║\n" "${updated}"
+
+    # Show minimal digest for UBI9
+    if [[ "${name}" == "ubi9" ]]; then
+      local minimal_digest
+      minimal_digest=$(jq -r '.minimal.digest // empty' "${lock_file}")
+      if [[ -n "${minimal_digest}" ]]; then
+        printf "║   Minimal:  %-60s ║\n" "${minimal_digest:0:50}..."
+      fi
+    fi
+
+    echo "╠════════════════════════════════════════════════════════════════════════════╣"
+  done
+
+  echo "╚════════════════════════════════════════════════════════════════════════════╝"
+}
+
+# Generate PR description for version updates
+generate_pr_body() {
+  local old_branch="${1:-main}"
+
+  echo "## Base Image Updates"
+  echo ""
+  echo "This PR updates base image digests to their latest versions."
+  echo ""
+  echo "| Image | Registry | New Digest |"
+  echo "|-------|----------|------------|"
+
+  for lock_file in "${VERSIONS_DIR}"/*.lock; do
+    local name registry digest
+    name=$(basename "${lock_file}" .lock)
+    registry=$(jq -r '.registry' "${lock_file}")
+    digest=$(jq -r '.digest' "${lock_file}")
+
+    echo "| ${name} | ${registry} | \`${digest:0:20}...\` |"
+  done
+
+  echo ""
+  echo "---"
+  echo ""
+  echo "Generated by: \`./scripts/refresh-versions.sh --apply\`"
+}
+
+# Main
+main() {
+  local cmd="${1:-}"
+  shift || true
+
+  case "${cmd}" in
+    get)
+      if [[ $# -lt 2 ]]; then
+        echo "Usage: $0 get <lock> <key>" >&2
+        echo "Example: $0 get wolfi .digest" >&2
+        return 1
+      fi
+      get_value "$1" "$2"
+      ;;
+    digest)
+      if [[ $# -lt 1 ]]; then
+        echo "Usage: $0 digest <image-type>" >&2
+        echo "Types: wolfi, alpine, ubi9, ubi9-minimal, distroless" >&2
+        return 1
+      fi
+      get_digest "$1"
+      ;;
+    env)
+      output_env
+      ;;
+    bake-vars)
+      output_bake_vars
+      ;;
+    validate)
+      validate_locks
+      ;;
+    summary)
+      show_summary
+      ;;
+    pr-body)
+      generate_pr_body "${1:-main}"
+      ;;
+    *)
+      echo "lockfile-util.sh - Utilities for version lock files"
+      echo ""
+      echo "Usage: $0 <command> [args]"
+      echo ""
+      echo "Commands:"
+      echo "  get <lock> <key>    Get a value from lock file (e.g., get wolfi .digest)"
+      echo "  digest <type>       Get digest for image type (wolfi, alpine, ubi9, ubi9-minimal, distroless)"
+      echo "  env                 Output as environment variables"
+      echo "  bake-vars           Output as docker-bake HCL variables"
+      echo "  validate            Validate all lock files"
+      echo "  summary             Show summary of all lock files"
+      echo "  pr-body             Generate PR description body"
+      echo ""
+      echo "Examples:"
+      echo "  $0 digest wolfi"
+      echo "  eval \$($0 env)"
+      echo "  $0 bake-vars > versions.hcl"
+      return 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/refresh-versions.sh
+++ b/scripts/refresh-versions.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# refresh-versions.sh - Detect and update base image digests and package versions
+#
+# Usage:
+#   ./scripts/refresh-versions.sh --check    # Check if updates are available (exit 1 if updates found)
+#   ./scripts/refresh-versions.sh --apply    # Apply updates to lock files
+#   ./scripts/refresh-versions.sh --diff     # Show differences without applying
+#
+# Requirements: docker, jq, curl
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERSIONS_DIR="${REPO_ROOT}/versions"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# Get latest digest for an image
+get_latest_digest() {
+  local image="$1"
+  docker buildx imagetools inspect "${image}" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"'
+}
+
+# Get package versions from Wolfi image
+get_wolfi_packages() {
+  local digest="$1"
+  local image="cgr.dev/chainguard/wolfi-base@${digest}"
+
+  docker run --rm "${image}" sh -c "apk list --installed 2>/dev/null" | \
+    awk -F' ' '{gsub(/-[0-9].*/, "", $1); print $1}' | sort -u
+}
+
+# Get specific package version from Wolfi
+get_wolfi_package_version() {
+  local digest="$1"
+  local package="$2"
+  local image="cgr.dev/chainguard/wolfi-base@${digest}"
+
+  docker run --rm "${image}" sh -c "apk list --installed 2>/dev/null | grep '^${package}-[0-9]'" | \
+    awk '{print $1}' | sed "s/^${package}-//"
+}
+
+# Get specific package version from Alpine
+get_alpine_package_version() {
+  local digest="$1"
+  local package="$2"
+  local image="alpine:3.20@${digest}"
+
+  docker run --rm "${image}" sh -c "apk info -v ${package} 2>/dev/null" | \
+    head -1 | sed "s/^${package}-//"
+}
+
+# Update Wolfi lock file
+update_wolfi_lock() {
+  local lock_file="${VERSIONS_DIR}/wolfi.lock"
+  local current_digest latest_digest
+
+  current_digest=$(jq -r '.digest' "${lock_file}")
+  latest_digest=$(get_latest_digest "cgr.dev/chainguard/wolfi-base:latest")
+
+  if [[ -z "${latest_digest}" ]]; then
+    log_error "Failed to get latest Wolfi digest"
+    return 1
+  fi
+
+  if [[ "${current_digest}" == "${latest_digest}" ]]; then
+    log_info "Wolfi: No digest change"
+    return 0
+  fi
+
+  log_info "Wolfi: Digest changed ${current_digest:0:20}... -> ${latest_digest:0:20}..."
+
+  # Get package versions
+  local packages
+  packages=$(jq -r '.packages | keys[]' "${lock_file}")
+
+  local tmp_file
+  tmp_file=$(mktemp)
+  jq --arg digest "${latest_digest}" \
+     --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.digest = $digest | .updated = $updated' "${lock_file}" > "${tmp_file}"
+
+  for pkg in ${packages}; do
+    local version
+    version=$(get_wolfi_package_version "${latest_digest}" "${pkg}" 2>/dev/null || echo "")
+    if [[ -n "${version}" ]]; then
+      jq --arg pkg "${pkg}" --arg ver "${version}" \
+         '.packages[$pkg] = $ver' "${tmp_file}" > "${tmp_file}.new"
+      mv "${tmp_file}.new" "${tmp_file}"
+      log_info "  ${pkg}: ${version}"
+    fi
+  done
+
+  mv "${tmp_file}" "${lock_file}"
+  return 2  # Indicates changes were made
+}
+
+# Update Alpine lock file
+update_alpine_lock() {
+  local lock_file="${VERSIONS_DIR}/alpine.lock"
+  local current_digest latest_digest
+
+  current_digest=$(jq -r '.digest' "${lock_file}")
+  latest_digest=$(get_latest_digest "alpine:3.20")
+
+  if [[ -z "${latest_digest}" ]]; then
+    log_error "Failed to get latest Alpine digest"
+    return 1
+  fi
+
+  if [[ "${current_digest}" == "${latest_digest}" ]]; then
+    log_info "Alpine: No digest change"
+    return 0
+  fi
+
+  log_info "Alpine: Digest changed ${current_digest:0:20}... -> ${latest_digest:0:20}..."
+
+  local packages
+  packages=$(jq -r '.packages | keys[]' "${lock_file}")
+
+  local tmp_file
+  tmp_file=$(mktemp)
+  jq --arg digest "${latest_digest}" \
+     --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.digest = $digest | .updated = $updated' "${lock_file}" > "${tmp_file}"
+
+  for pkg in ${packages}; do
+    local version
+    version=$(get_alpine_package_version "${latest_digest}" "${pkg}" 2>/dev/null || echo "")
+    if [[ -n "${version}" ]]; then
+      jq --arg pkg "${pkg}" --arg ver "${version}" \
+         '.packages[$pkg] = $ver' "${tmp_file}" > "${tmp_file}.new"
+      mv "${tmp_file}.new" "${tmp_file}"
+      log_info "  ${pkg}: ${version}"
+    fi
+  done
+
+  mv "${tmp_file}" "${lock_file}"
+  return 2
+}
+
+# Update UBI9 lock file
+update_ubi9_lock() {
+  local lock_file="${VERSIONS_DIR}/ubi9.lock"
+  local current_digest latest_digest
+  local current_minimal_digest latest_minimal_digest
+  local changes=0
+
+  current_digest=$(jq -r '.digest' "${lock_file}")
+  latest_digest=$(get_latest_digest "registry.access.redhat.com/ubi9/ubi:latest")
+
+  current_minimal_digest=$(jq -r '.minimal.digest' "${lock_file}")
+  latest_minimal_digest=$(get_latest_digest "registry.access.redhat.com/ubi9-minimal:latest")
+
+  if [[ -z "${latest_digest}" ]] || [[ -z "${latest_minimal_digest}" ]]; then
+    log_error "Failed to get latest UBI9 digests"
+    return 1
+  fi
+
+  local tmp_file
+  tmp_file=$(mktemp)
+  cp "${lock_file}" "${tmp_file}"
+
+  if [[ "${current_digest}" != "${latest_digest}" ]]; then
+    log_info "UBI9: Digest changed ${current_digest:0:20}... -> ${latest_digest:0:20}..."
+    jq --arg digest "${latest_digest}" '.digest = $digest' "${tmp_file}" > "${tmp_file}.new"
+    mv "${tmp_file}.new" "${tmp_file}"
+    changes=1
+  else
+    log_info "UBI9: No digest change"
+  fi
+
+  if [[ "${current_minimal_digest}" != "${latest_minimal_digest}" ]]; then
+    log_info "UBI9-minimal: Digest changed ${current_minimal_digest:0:20}... -> ${latest_minimal_digest:0:20}..."
+    jq --arg digest "${latest_minimal_digest}" '.minimal.digest = $digest' "${tmp_file}" > "${tmp_file}.new"
+    mv "${tmp_file}.new" "${tmp_file}"
+    changes=1
+  else
+    log_info "UBI9-minimal: No digest change"
+  fi
+
+  if [[ ${changes} -eq 1 ]]; then
+    jq --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.updated = $updated' "${tmp_file}" > "${tmp_file}.new"
+    mv "${tmp_file}.new" "${lock_file}"
+    return 2
+  fi
+
+  rm -f "${tmp_file}"
+  return 0
+}
+
+# Update Distroless lock file
+update_distroless_lock() {
+  local lock_file="${VERSIONS_DIR}/distroless.lock"
+  local current_digest latest_digest
+
+  current_digest=$(jq -r '.digest' "${lock_file}")
+  latest_digest=$(get_latest_digest "gcr.io/distroless/base-debian12:latest")
+
+  if [[ -z "${latest_digest}" ]]; then
+    log_error "Failed to get latest Distroless digest"
+    return 1
+  fi
+
+  if [[ "${current_digest}" == "${latest_digest}" ]]; then
+    log_info "Distroless: No digest change"
+    return 0
+  fi
+
+  log_info "Distroless: Digest changed ${current_digest:0:20}... -> ${latest_digest:0:20}..."
+
+  jq --arg digest "${latest_digest}" \
+     --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.digest = $digest | .updated = $updated' "${lock_file}" > "${lock_file}.tmp"
+  mv "${lock_file}.tmp" "${lock_file}"
+  return 2
+}
+
+# Check mode - just report if updates available
+check_updates() {
+  log_info "Checking for base image updates..."
+  local has_updates=0
+
+  for lock_file in "${VERSIONS_DIR}"/*.lock; do
+    local name
+    name=$(basename "${lock_file}" .lock)
+    local registry digest latest_digest
+
+    registry=$(jq -r '.registry' "${lock_file}")
+    digest=$(jq -r '.digest' "${lock_file}")
+
+    # Determine the full image reference
+    local image_ref
+    case "${name}" in
+      wolfi)   image_ref="cgr.dev/chainguard/wolfi-base:latest" ;;
+      alpine)  image_ref="alpine:3.20" ;;
+      ubi9)    image_ref="registry.access.redhat.com/ubi9/ubi:latest" ;;
+      distroless) image_ref="gcr.io/distroless/base-debian12:latest" ;;
+      *)       continue ;;
+    esac
+
+    latest_digest=$(get_latest_digest "${image_ref}" 2>/dev/null || echo "")
+
+    if [[ -z "${latest_digest}" ]]; then
+      log_warn "${name}: Could not fetch latest digest"
+      continue
+    fi
+
+    if [[ "${digest}" != "${latest_digest}" ]]; then
+      log_warn "${name}: Update available"
+      log_info "  Current: ${digest:0:20}..."
+      log_info "  Latest:  ${latest_digest:0:20}..."
+      has_updates=1
+    else
+      log_info "${name}: Up to date"
+    fi
+  done
+
+  if [[ ${has_updates} -eq 1 ]]; then
+    log_warn "Updates are available. Run with --apply to update lock files."
+    return 1
+  fi
+
+  log_info "All lock files are up to date."
+  return 0
+}
+
+# Apply updates to lock files
+apply_updates() {
+  log_info "Applying base image updates..."
+  local total_changes=0
+
+  update_wolfi_lock || { [[ $? -eq 2 ]] && ((total_changes++)); }
+  update_alpine_lock || { [[ $? -eq 2 ]] && ((total_changes++)); }
+  update_ubi9_lock || { [[ $? -eq 2 ]] && ((total_changes++)); }
+  update_distroless_lock || { [[ $? -eq 2 ]] && ((total_changes++)); }
+
+  if [[ ${total_changes} -gt 0 ]]; then
+    log_info "Updated ${total_changes} lock file(s)"
+    return 0
+  fi
+
+  log_info "No updates applied"
+  return 0
+}
+
+# Show diff without applying
+show_diff() {
+  log_info "Checking differences (dry-run)..."
+  check_updates
+}
+
+# Main
+main() {
+  local mode="${1:-}"
+
+  case "${mode}" in
+    --check)
+      check_updates
+      ;;
+    --apply)
+      apply_updates
+      ;;
+    --diff)
+      show_diff
+      ;;
+    *)
+      echo "Usage: $0 {--check|--apply|--diff}"
+      echo ""
+      echo "Options:"
+      echo "  --check   Check if updates are available (exit 1 if updates found)"
+      echo "  --apply   Apply updates to lock files"
+      echo "  --diff    Show differences without applying"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/versions/alpine.lock
+++ b/versions/alpine.lock
@@ -1,0 +1,16 @@
+{
+  "registry": "docker.io/library/alpine",
+  "tag": "3.20",
+  "digest": "sha256:765942a4039992336de8dd5db680586e1a206607dd06170ff0a37267a9e01958",
+  "updated": "2026-01-27T00:00:00Z",
+  "packages": {
+    "curl": "",
+    "coreutils": "",
+    "bash": "",
+    "python3": "",
+    "ca-certificates": "",
+    "netcat-openbsd": "",
+    "bind-tools": ""
+  },
+  "_comment": "Package versions populated by scripts/refresh-versions.sh"
+}

--- a/versions/distroless.lock
+++ b/versions/distroless.lock
@@ -1,0 +1,8 @@
+{
+  "registry": "gcr.io/distroless/base-debian12",
+  "tag": "latest",
+  "digest": "sha256:0c70ab46409b94a96f4e98e32e7333050581e75f7038de2877a4bfc146dfc7ce",
+  "updated": "2026-01-27T00:00:00Z",
+  "packages": {},
+  "_comment": "Distroless has no package manager; only digest is tracked"
+}

--- a/versions/ubi9.lock
+++ b/versions/ubi9.lock
@@ -1,0 +1,13 @@
+{
+  "registry": "registry.access.redhat.com/ubi9/ubi",
+  "tag": "latest",
+  "digest": "sha256:c8df11b65b18fcf384d5b7fa53e2a92f381a2d9ad78b9de41dc6f2aa161a0e04",
+  "updated": "2026-01-27T00:00:00Z",
+  "minimal": {
+    "registry": "registry.access.redhat.com/ubi9-minimal",
+    "tag": "latest",
+    "digest": "sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829"
+  },
+  "packages": {},
+  "_comment": "UBI9 uses dnf/microdnf; package versions not pinned"
+}

--- a/versions/wolfi.lock
+++ b/versions/wolfi.lock
@@ -1,0 +1,18 @@
+{
+  "registry": "cgr.dev/chainguard/wolfi-base",
+  "tag": "latest",
+  "digest": "sha256:f6959a1b0ed7e6f4696f5cd8373b28846494cb9272a14dc0ddc0db94d00e7344",
+  "updated": "2026-01-27T00:00:00Z",
+  "packages": {
+    "curl": "",
+    "coreutils": "",
+    "bash": "",
+    "python-3.12": "",
+    "ca-certificates": "",
+    "glibc": "",
+    "glibc-locale-posix": "",
+    "libgcc": "",
+    "binutils": ""
+  },
+  "_comment": "Package versions populated by scripts/refresh-versions.sh"
+}


### PR DESCRIPTION
## Summary

Replace custom digest-refresh workflow with Renovate for automated base image digest management.

### Changes

- Add `renovate.json` with `docker:pinDigests` preset and weekly schedule (Monday 06:00 UTC)
- Configure package rules to group updates by image family:
  - `chainguard-base-images` (Wolfi, Alpine)
  - `distroless-base-images` (base-debian12)
  - `ubi9-base-images` (ubi9/ubi, ubi9-minimal)
- Update all 9 Dockerfiles to use inline digest format with `# renovate:` comments
- Remove ARG-based digest variables in favor of inline FROM statements

### Dockerfile Format Change

```dockerfile
# Before (ARG variable)
ARG WOLFI_DIGEST="sha256:..."
FROM cgr.dev/chainguard/wolfi-base@${WOLFI_DIGEST}

# After (inline with Renovate comment)
# renovate: datasource=docker
FROM cgr.dev/chainguard/wolfi-base:latest@sha256:...
```

### Benefits of Renovate

| Aspect | Custom Solution | Renovate |
|--------|-----------------|----------|
| Maintenance | Team-maintained | Community-maintained |
| Error handling | Basic | Robust (retries, rate limits) |
| Ecosystems | Docker only | Docker, npm, Helm, K8s, etc. |
| PR management | Manual | Auto-rebase, conflict resolution |
| Grouping | None | Group related updates |

## Next Steps (after merge)

1. Install [Renovate GitHub App](https://github.com/apps/renovate) on repository
2. Review and merge Renovate onboarding PR
3. Optionally remove custom `digest-refresh.yml` workflow and scripts

## Test plan

- [ ] CI builds pass with updated Dockerfile format
- [ ] Renovate config validates (JSON schema)
- [ ] After Renovate app install, verify dependency dashboard is created

Closes #46
Supersedes approach in #44 (can close PR #45 if not merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)