### PR TITLE
fix: export env vars for Python in attest_jdk_resolution.sh

### DIFF
--- a/scripts/attest_jdk_resolution.sh
+++ b/scripts/attest_jdk_resolution.sh
@@ -53,6 +53,8 @@ esac
 entries='[]'
 for arch in amd64 arm64; do
   # Clear optional variables that may or may not be set by resolve_jdk.sh
+  unset VERSION JDK_URL JDK_SHA256 SIGNATURE_URL
+  # Clear optional variables that may or may not be set by resolve_jdk.sh
   # to prevent stale values from previous iterations
   unset VERSION JDK_URL JDK_SHA256 SIGNATURE_URL
 

--- a/scripts/attest_jdk_resolution.sh
+++ b/scripts/attest_jdk_resolution.sh
@@ -52,8 +52,27 @@ esac
 
 entries='[]'
 for arch in amd64 arm64; do
+  # Clear optional variables that may or may not be set by resolve_jdk.sh
+  # to prevent stale values from previous iterations
+  unset VERSION JDK_URL JDK_SHA256 SIGNATURE_URL
+
   env_output="$($RESOLVER --flavor=${flavor} --arch=${arch} --libc=${libc} --type=${type})"
-  eval "$env_output"
+
+  # Safely parse resolver output (KEY=VALUE format) without using eval.
+  # This treats the resolver output as data and avoids executing any embedded shell.
+  for assignment in $env_output; do
+    case "$assignment" in
+      *=*)
+        name="${assignment%%=*}"
+        value="${assignment#*=}"
+        # Only allow uppercase shell variable names (ARCH, LIBC, etc.)
+        if [[ "$name" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+          printf -v "$name" '%s' "$value"
+        fi
+        ;;
+    esac
+  done
+
   export ARCH LIBC FLAVOR VERSION JDK_URL JDK_SHA256 SIGNATURE_URL TYPE
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   entries=$(ENTRIES="$entries" TIMESTAMP="$timestamp" python3 <<'PY'

--- a/scripts/attest_jdk_resolution.sh
+++ b/scripts/attest_jdk_resolution.sh
@@ -54,6 +54,7 @@ entries='[]'
 for arch in amd64 arm64; do
   env_output="$($RESOLVER --flavor=${flavor} --arch=${arch} --libc=${libc} --type=${type})"
   eval "$env_output"
+  export ARCH LIBC FLAVOR VERSION JDK_URL JDK_SHA256 SIGNATURE_URL TYPE
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   entries=$(ENTRIES="$entries" TIMESTAMP="$timestamp" python3 <<'PY'
 import json, os


### PR DESCRIPTION
The eval command only sets shell variables, not environment variables. Python's os.environ needs exported variables to be accessible.

Add export statement after eval to make ARCH, LIBC, FLAVOR, VERSION, JDK_URL, JDK_SHA256, SIGNATURE_URL, and TYPE available to the embedded Python script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of change
- [ ] Spec
- [ ] Proposal
- [ ] Implementation
- [ ] Fix

## Spec/Proposal reference (required for implementations)
- Spec issue: #
- OpenSpec change: `openspec/changes/<change-id>/`

## Summary of changes
-

## Spec compliance checklist
- [ ] I reviewed the spec acceptance criteria and confirmed coverage.
- [ ] The implementation matches the OpenSpec proposal and tasks.
- [ ] No out-of-scope changes were introduced.
- [ ] Docs/specs updated if required.

## Testing checklist
- [ ] `make build` completes successfully
- [ ] `make scan` passes (no HIGH/CRITICAL CVEs)
- [ ] Multi-arch build verified (if applicable)
- [ ] Container runs with expected behavior

## Breaking changes
- [ ] This PR introduces breaking changes (describe below)

Details:

## Screenshots/logs (if applicable)

