### PR TITLE
fix: pin all GitHub Actions to commit SHAs in ci-build.yml

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,20 +36,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Lowercase Image Name
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Build CI image
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
         env:
           REGISTRY: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         with:
@@ -71,7 +71,7 @@ jobs:
         run: ./scripts/validate_hardening.sh ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.target }}
 
       - name: Run Trivy vulnerability scanner (Critical only)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.target }}
           format: 'table'


### PR DESCRIPTION
All 5 actions were using mutable tag references (@v4, @v3, @v6, @master), making them vulnerable to supply chain attacks. Pin each to its verified commit SHA, consistent with all other workflows in this repo.

Most critically, aquasecurity/trivy-action@master was pinned to v0.35.0 which patches CVE-2026-26189 (script injection) and post-dates the March 2026 Trivy ecosystem supply chain compromise.

## Type of change
- [ ] Spec
- [ ] Proposal
- [ ] Implementation
- [ ] Fix

## Spec/Proposal reference (required for implementations)
- Spec issue: #
- OpenSpec change: `openspec/changes/<change-id>/`

## Summary of changes
-

## Spec compliance checklist
- [ ] I reviewed the spec acceptance criteria and confirmed coverage.
- [ ] The implementation matches the OpenSpec proposal and tasks.
- [ ] No out-of-scope changes were introduced.
- [ ] Docs/specs updated if required.

## Testing checklist
- [ ] `make build` completes successfully
- [ ] `make scan` passes (no HIGH/CRITICAL CVEs)
- [ ] Multi-arch build verified (if applicable)
- [ ] Container runs with expected behavior

## Breaking changes
- [ ] This PR introduces breaking changes (describe below)

Details:

## Screenshots/logs (if applicable)

